### PR TITLE
Optimize the ads1115 driver-code

### DIFF
--- a/dts/bindings/sensor/ti,ads1115.yaml
+++ b/dts/bindings/sensor/ti,ads1115.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2019, Actinius
+# SPDX-License-Identifier: Apache-2.0
+
+description: Texas Instruments ADS1115 analog-to-digital converters
+
+compatible: "ti,ads1115"
+
+include: i2c-device.yaml
+
+properties:
+    sampling_channel:
+      type: int
+      required: true
+      description: Choose a channel to sample
+
+    continuous_mode:
+      type: int
+      required: true
+      description: if continuous_mode equal to zero, the device is in single mode. Other value is in continuous_mode.
+
+    int_gpios:
+      type: phandle-array
+      required: false
+      description: DRDY/INT pin.
+
+        The DRDY/INT pin of ADS1115 sensor is open-drain, active low. If
+        connected directly the MCU pin should be configured as pull-up
+        as pull-up, active low.


### PR DESCRIPTION
	-- refactor
	       1. configure the sampling channel and continuous mode in the device tree.

	-- new
		1. add dts/bindings/sensor/ti,ads1115.yaml file