### PR TITLE
boards: beagle_bcf: attempt to fix mikroBUS UART0 pin swap

### DIFF
--- a/boards/arm/beagle_bcf/CMakeLists.txt
+++ b/boards/arm/beagle_bcf/CMakeLists.txt
@@ -3,6 +3,7 @@
 zephyr_library()
 zephyr_library_sources(
     board_antenna.c
+    board_uartpinmux.c
     )
 
 zephyr_library_compile_definitions("DeviceFamily_CC13X2")

--- a/boards/arm/beagle_bcf/Kconfig.board
+++ b/boards/arm/beagle_bcf/Kconfig.board
@@ -18,4 +18,10 @@ config BOARD_ANTENNA_INIT_PRIO
 	  KERNEL_INIT_PRIORITY_DEVICE but smaller than
 	  IEEE802154_CC13XX_CC26XX_SUB_GHZ_INIT_PRIO.
 
+config BOARD_UARTMUX_INIT_PRIO
+	int "Board UART mux initialization priority"
+	default 71
+	help
+	  Set the priority for board UART mux switch init
+
 endif # BOARD_BEAGLECONNECT_FREEDOM

--- a/boards/arm/beagle_bcf/board_uartpinmux.c
+++ b/boards/arm/beagle_bcf/board_uartpinmux.c
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2021 Vaishnav, BeagleBoard.org Foundation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Implements mechanism to swap UART pins according to operating mode                               
+ */
+                                                 
+#include <zephyr.h>
+#include <device.h>
+#include <init.h>
+#include <errno.h>
+#include <drivers/uart.h>
+#include <shell/shell.h>
+#include <driverlib/ioc.h>
+#include <drivers/i2c.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#define UARTPINMUX_MODE_MIKROBUS 0x0A
+#define UARTPINMUX_MODE_MSP430 0x0B
+
+#define MSP430_SLAVE_ADDR 0x04
+#define MSP430_I2CSLAVE_SET_UARTMIKROBUS_REG 0x08
+#define MSP430_I2CSLAVE_SET_UARTMSP430_REG 0x09
+#define MSP430_I2CSLAVE_GET_UARTMUX_REG 0x0C
+
+#define IOC_PORT_MCU_UART0_TX 0x00000010
+#define IOC_PORT_MCU_UART0_RX 0x0000000F
+
+#define MIKROBUS0_UART0_PIN_RX 13
+#define MIKROBUS0_UART0_PIN_TX 12
+
+static int uartpinmuxget()
+{
+    const struct device *i2cmaster = device_get_binding("I2C_0");
+    int ret;
+    uint8_t rdbuf[1];
+
+    ret = i2c_reg_read_byte(i2cmaster, MSP430_SLAVE_ADDR, MSP430_I2CSLAVE_GET_UARTMUX_REG, rdbuf);
+    return rdbuf[0];
+}
+
+static int uartpinmuxset(uint8_t mode)
+{
+    const struct device *i2cmaster = device_get_binding("I2C_0");
+    int ret;
+
+    if(mode == UARTPINMUX_MODE_MIKROBUS){
+        ret = i2c_reg_write_byte(i2cmaster, MSP430_SLAVE_ADDR, MSP430_I2CSLAVE_SET_UARTMIKROBUS_REG, 0);
+        k_sleep(K_MSEC(100));
+        while(uartpinmuxget() != UARTPINMUX_MODE_MIKROBUS);
+        IOCPortConfigureSet(MIKROBUS0_UART0_PIN_RX, IOC_PORT_MCU_UART0_RX, IOC_STD_INPUT);
+        IOCPortConfigureSet(MIKROBUS0_UART0_PIN_TX, IOC_PORT_MCU_UART0_TX, IOC_STD_OUTPUT);
+    }
+    else if(mode == UARTPINMUX_MODE_MSP430){
+        IOCPortConfigureSet(MIKROBUS0_UART0_PIN_RX, IOC_PORT_MCU_UART0_TX, IOC_STD_OUTPUT);
+        IOCPortConfigureSet(MIKROBUS0_UART0_PIN_TX, IOC_PORT_MCU_UART0_RX, IOC_STD_INPUT);
+        k_sleep(K_MSEC(100));
+        ret = i2c_reg_write_byte(i2cmaster, MSP430_SLAVE_ADDR, MSP430_I2CSLAVE_SET_UARTMSP430_REG, 0);
+        while(uartpinmuxget() != UARTPINMUX_MODE_MSP430);
+    }
+    return ret;
+}
+
+static int cmd_uartpinmuxget(const struct shell *shell, size_t argc,
+			      char **argv)
+{
+    int uartpinmux_mode = uartpinmuxget();
+
+    if(uartpinmux_mode == UARTPINMUX_MODE_MIKROBUS){
+    	shell_print(shell, "Current UART pinmux setting : mikrobus");
+    }
+    else if(uartpinmux_mode == UARTPINMUX_MODE_MSP430){
+        shell_print(shell, "Current UART pinmux setting : msp430");
+    }
+    else{
+        shell_print(shell, "Invalid UART pinmux seting");
+    }
+    
+	return 0;
+}
+
+
+static int cmd_uartpinmuxset(const struct shell *shell, size_t argc,
+			      char **argv)
+{
+    int uartpinmux_mode = 0;
+    int currentpinmux_mode = uartpinmuxget();
+
+    uartpinmux_mode = strcmp(argv[1], "mikrobus") ? 
+                      (strcmp(argv[1], "msp430") ? 0 : UARTPINMUX_MODE_MSP430)
+                      : UARTPINMUX_MODE_MIKROBUS;
+
+    if(uartpinmux_mode){
+        if(currentpinmux_mode == uartpinmux_mode){
+            shell_print(shell, "current UART pinmux mode is same as requested mode : %s", argv[1]);
+            return 0;
+        }     
+    	shell_print(shell, "setting UART pinmux setting: %s", argv[1]);
+        k_sleep(K_MSEC(100));
+        uartpinmuxset(uartpinmux_mode);
+    }
+    else{
+        shell_print(shell, "invalid UART pinmux setting: %s", argv[1]);
+        return -EINVAL;
+    } 
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_uartpinmux,
+	SHELL_CMD_ARG(set, NULL,
+		  "Set UART Pinmux setting to desired mode [msp430(default)|mikrobus]",
+		  cmd_uartpinmuxset, 2, 0),
+    SHELL_CMD_ARG(get, NULL,
+		  "Get current UART Pinmux setting, returns: [msp430|mikrobus]",
+		  cmd_uartpinmuxget, 1, 0),
+	SHELL_SUBCMD_SET_END /* Array terminated. */
+);
+SHELL_CMD_REGISTER(uartpinmux, &sub_uartpinmux, "UART Pinmux setting", NULL);


### PR DESCRIPTION
Attempt to fix https://github.com/jadonk/beagleconnect/issues/67

The scheme followed is to use the I2C communication between
CC1352 and MSP430 to set the analog SPDT switch state and also
the IOC pinmux state on CC1352 accordingly after/before setting the switch,
currently exposed as shell interface, but can be included in application startup
as well.

All changes were tested on BeagleConnect Freedom Rev C5

Since CC1352 is always in control of which state the analog switch is
in, we will not face a combination where TX-TX is connected together.

Shell Interface:

uart:~$ uartpinmux
uartpinmux - UART Pinmux setting
Subcommands:
  set  :Set UART Pinmux setting to desired mode [msp430(default)|mikrobus]
  get  :Get current UART Pinmux setting, returns: [msp430|mikrobus]

uart:~$ uartpinmux get
Current UART pinmux setting : msp430

uart:~$ uartpinmux set mikrobus
setting UART pinmux setting: mikrobus
