### PR TITLE
west: update west.yml for greybus-mikrobus

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -23,6 +23,9 @@ manifest:
       url-base: https://github.com/zephyrproject-rtos
     - name: bcf-sdk
       url-base: https://github.com/jadonk
+    - name: manifesto-remote
+      url-base: https://github.com/vaishnav98
+
 
   #
   # Please add items below based on alphabetical order
@@ -57,7 +60,11 @@ manifest:
     - name: greybus-for-zephyr
       remote: bcf-sdk
       path: modules/lib/greybus
-      revision: mikrobus
+      revision: mikrobus-2.7-hacks
+    - name: manifesto
+      remote: manifesto-remote
+      path: modules/lib/greybus/scripts/manifesto
+      revision: zephyr
 
   group-filter:
     - -ci


### PR DESCRIPTION
update greybus-mikrobus version to mikrobus-2.7-hacks
manifesto submodule is missed in the greybus module,
so add it manually in west.